### PR TITLE
Update setup-key.sh

### DIFF
--- a/kafka/setup-key.sh
+++ b/kafka/setup-key.sh
@@ -34,14 +34,14 @@ key_vault_name=$(echo "$AZURE_AKV_RESOURCE_ENDPOINT" | cut -d. -f1)
 echo "Key vault name is ${key_vault_name}"
 
 if [[ "$AZURE_AKV_RESOURCE_ENDPOINT" == *".vault.azure.net" ]]; then
-	if [[ $(az keyvault list | grep "Microsoft.KeyVault/vaults/${key_vault_name}" ) ]] 2>/dev/null; then
+	if [[ $(az keyvault list -o json| grep "Microsoft.KeyVault/vaults/${key_vault_name}" ) ]] 2>/dev/null; then
 		echo "AKV endpoint OK"
 	else
 		echo "Azure akv resource endpoint doesn't exist. Please refer to documentation instructions to set it up first:"
 		exit 1
 	fi
 elif [[ "$AZURE_AKV_RESOURCE_ENDPOINT" == *".managedhsm.azure.net" ]]; then
-	if [[ $(az keyvault list | grep "Microsoft.KeyVault/managedHSMs/${key_vault_name}" ) ]] 2>/dev/null; then
+	if [[ $(az keyvault list -o json| grep "Microsoft.KeyVault/managedHSMs/${key_vault_name}" ) ]] 2>/dev/null; then
 		echo "AKV endpoint OK"
 	else
 		echo "Azure akv resource endpoint doesn't exist. Please refer to documentation instructions to set it up first:"


### PR DESCRIPTION
fixing command to not assume default json output format for Azure CLI. Users with default output set to 'table' will get false errors as the value in the grep does not exist in table output format.

Fixes issue #8 